### PR TITLE
Fix mac compilation error

### DIFF
--- a/include/System.h
+++ b/include/System.h
@@ -58,6 +58,8 @@ public:
     pangolin::OpenGlRenderState s_cam;
     pangolin::View d_cam;
 
+    FeatureTracker trackerData[NUM_OF_CAM];
+
 #ifdef __APPLE__
     void InitDrawGL(); 
     void DrawGLFrame();
@@ -73,7 +75,6 @@ private:
     // ros::Publisher pub_img, pub_match;
     // ros::Publisher pub_restart;
 
-    FeatureTracker trackerData[NUM_OF_CAM];
     double first_image_time;
     int pub_count = 1;
     bool first_image_flag = true;

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -475,4 +475,5 @@ void System::DrawGLFrame()
         pangolin::FinishFrame();
         usleep(5000);   // sleep 5 ms
     }
+}
 #endif


### PR DESCRIPTION
 - Add enclosing bracket for mac platform

 - Make FeatureTracker public so it could be accessed in main thread drawing function. However this seems causing trajectory to diverge